### PR TITLE
All arguments should be passed down

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,17 +4,17 @@ const compose = (...fns) => fns.reduce((f, g) => (...args) =>
   // Allow falsey functions to be passed in, by passing over them
   g ? f(g(...args)) : f(...args),
   // Set initial value with blank HOF, so "f" above is always truthy on first iteration
-  fn => async (req, res) => fn(req, res)
+  fn => async (...args) => fn(...args)
 )
 
-const respondToLivenessProbe = fn => async (req, res) => {
+const respondToLivenessProbe = fn => async (req, ...args) => {
   if (req.method == 'GET' && req.url == '/') return { healthy: true }
-  return fn(req, res)
+  return fn(req, ...args)
 }
 
-const parseJSONInput = fn => async (req, res) => {
+const parseJSONInput = fn => async (req, ...args) => {
   if (req.headers['content-type'] === 'application/json') req.json = await json(req)
-  return fn(req, res)
+  return fn(req, ...args)
 }
 
 module.exports = { compose, respondToLivenessProbe, parseJSONInput }


### PR DESCRIPTION
Hello!

In current implementation functions passing down only req and res.
Unfortunately, middleware like that will not works correct:
```js
const middle = fn => async(req, res) => {
  
  return fn(req, res, { message: 'new object' });
};
```

Because this module expose higher-order functions, we need to handle correct functions that returns more than 2 arguments.